### PR TITLE
Fixed command conflict

### DIFF
--- a/src/main/java/com/realxode/kumareports/Main.java
+++ b/src/main/java/com/realxode/kumareports/Main.java
@@ -41,7 +41,7 @@ public final class Main extends JavaPlugin {
                 e.printStackTrace();
             }
             try {
-                this.getCommand("help").setExecutor(new AyudaCommand(this));
+                this.getCommand("report").setExecutor(new AyudaCommand(this));
                 sendConsoleMsg("&6Plugin enabled succesfully! Currently plugin version: &e" + version);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/main/java/com/realxode/kumareports/cmds/AyudaCommand.java
+++ b/src/main/java/com/realxode/kumareports/cmds/AyudaCommand.java
@@ -19,7 +19,7 @@ public class AyudaCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        if(label.equalsIgnoreCase("help")) {
+        if(label.equalsIgnoreCase("report")) {
 
             DiscordWebhook webhook = new DiscordWebhook(main.getUrl());
             if (sender instanceof Player) {

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -1,5 +1,5 @@
 ingame-prefix: "&c&lKuma&4&lReports &8&l| &f"
-invalid-usage: "&cInvalid usage! Use: /help <report, bug, other>!"
+invalid-usage: "&cInvalid usage! Use: /report <report, bug, other>!"
 successfully-sent-webhook: "&cReport sent!"
 Report:
   specify-player: "&cPlease, specify a valid player!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,5 +5,5 @@ authors: [ RealXode ]
 description: Report players and bugs.
 
 commands:
-  help:
-    description: Help command
+  report:
+    description: Report pleyers, bugs or ask for help


### PR DESCRIPTION
Command `help` can conflict with the spigot command `help`. Also, the command can get blocked by anti plugin steal plugins like [this](https://www.spigotmc.org/resources/canela-anti-pluginsteal.1150/) one.

Changes:
- Changed command from `help` to `report`
- Changed `lang.yml` file to reflect the new command name
- Changed description in `plugin.yml` to be more descriptive